### PR TITLE
boards explorer side-menu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Toolbar } from '../Components'
 import { Auth } from '../../services/Services'
 
 const auth = new Auth()
@@ -9,7 +8,6 @@ const { isAuthenticated } = auth
 const Board = () =>
   (isAuthenticated() &&
     <div>
-      <Toolbar />
       <h1>Project Board</h1>
     </div>
   )

--- a/src/components/Boards/Boards.js
+++ b/src/components/Boards/Boards.js
@@ -1,19 +1,37 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 
-import { Wrapper, Input, Button } from './Boards.styles'
+import { Wrapper, Input, Button, MenuHeader, Text } from './Boards.styles'
 
-import ZippyMenu from './Components/ZippyMenu'
+import ZippyMenu from './ZippyMenu/ZippyMenu'
 
-const Boards = () => {
-  return (
-    <Wrapper>
+const Boards = props => {
+  const ContentJSX = (
+    <Fragment>
+      {props.keepOpen &&
+        <MenuHeader>
+          <Text black>Menu</Text>
+        </MenuHeader>
+      }
       <Input type="search" placeholder="Find boards by name..." />
       <ZippyMenu title="Starred Boards" />
       <ZippyMenu title="Recent Boards" />
       <ZippyMenu title="Personal Boards" />
       <ZippyMenu title="Shared Boards" />
-      <Button secondary onClick={null}>Keep this tab open</Button>
-    </Wrapper>
+      <Button secondary onClick={props.toggleFixedMenu}>
+        {`${(props.keepOpen ? 'Don\'t' : 'Always')} keep this tab open`}
+      </Button>
+    </Fragment>
+  )
+
+  return (
+    props.keepOpen ?
+      <Wrapper alwaysOpen>
+        {ContentJSX}
+      </Wrapper> :
+      <Wrapper notAlwaysOpen>
+        {ContentJSX}
+      </Wrapper>
+
   )
 }
 

--- a/src/components/Boards/Boards.js
+++ b/src/components/Boards/Boards.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import { Wrapper, Input, Button } from './Boards.styles'
+
+import ZippyMenu from './Components/ZippyMenu'
+
+const Boards = () => {
+  return (
+    <Wrapper>
+      <Input type="search" placeholder="Find boards by name..." />
+      <ZippyMenu title="Starred Boards" />
+      <ZippyMenu title="Recent Boards" />
+      <ZippyMenu title="Personal Boards" />
+      <ZippyMenu title="Shared Boards" />
+      <Button secondary onClick={null}>Keep this tab open</Button>
+    </Wrapper>
+  )
+}
+
+export default Boards

--- a/src/components/Boards/Boards.styles.js
+++ b/src/components/Boards/Boards.styles.js
@@ -1,31 +1,49 @@
 import styled, { css } from 'styled-components'
 
 const Wrapper = styled.div`
-  top: 50px;
   left: 0;
   display: block;
   z-index: 99;
-  position: absolute;
-  border-radius: 0 3px 3px 0;
-  box-shadow: 0 3px 6px rgba(0,0,0,.4);
-  background: #9999FF;
   width: 280px;
   height: 1000px;
+
+  background: #9999FF;
+
+  ${props => props.notAlwaysOpen && css`
+    top: 44px;
+    position: absolute;
+    border-radius: 0 3px 3px 0;
+    box-shadow: 0 3px 6px rgba(0,0,0,.4);
+  `}
+
+  ${props => props.alwaysOpen && css`
+    top: 0;
+    position: fixed;
+    box-shadow: 0 0 6px rgba(0,0,0,.4);
+  `}
+  
 `
 const Input = styled.input`
   transition: background 85ms ease-in, border-color 85ms ease-in;
   width: 95%;
   border: 1px: solid grey;
   border-radius: 3px;
-  background: #E2E4E6;
   padding: 6px;
   border: none;
   height: 29px;
   margin: 6px;
+
+  background: #E2E4E6;
   
   &:focus {
     background: white;
   }
+`
+
+const MenuHeader = styled.div`
+  background: #7171bd;
+  padding: 11px 13px;
+  height: 18px;
 `
 
 const Icon = styled.span`
@@ -33,27 +51,12 @@ const Icon = styled.span`
   height: 20px;
   width: 20px;
   padding: 6px;
+
   color: #DDDDDD;
 
   &:hover {
     color: grey;
   }
-`
-
-const Pills = styled.div`
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  margin: 15px;
-  min-height: 35px;
-`
-
-const Pill = styled.div`
-  border-radius: 3px;
-  margin-top: 3px;
-  padding: 6px;
-  background: #DDDDDD;
-  width: 100%;
 `
 
 const Text = styled.span`
@@ -63,11 +66,12 @@ const Text = styled.span`
 const Button = styled.button`
   padding: 0;
   cursor: pointer;
-  color: #DDDDDD;  
-  background: #9999FF;
   border-radius: 4px;
   outline: none;
   border: none;
+
+  color: #DDDDDD;  
+  background: #9999FF;
 
   ${props => props.pull_right && css`
     margin-left: auto;
@@ -75,14 +79,15 @@ const Button = styled.button`
 
   ${props => props.secondary && css`
     border-radius: 3px;
-    color: grey;
     display: block;
     margin-top: 3px;
     margin-left: auto;
     margin-right: auto;
     padding: 6px;
-    background: #DDDDDD;
     width: 95%;
+
+    color: grey;
+    background: #DDDDDD;
 
     &:hover {
       color: #4c4c4c;
@@ -102,11 +107,10 @@ const Button = styled.button`
 `
 
 export {
+  MenuHeader,
   Button,
   Wrapper,
   Text,
   Input,
   Icon,
-  Pills,
-  Pill
 }

--- a/src/components/Boards/Boards.styles.js
+++ b/src/components/Boards/Boards.styles.js
@@ -1,0 +1,112 @@
+import styled, { css } from 'styled-components'
+
+const Wrapper = styled.div`
+  top: 50px;
+  left: 0;
+  display: block;
+  z-index: 99;
+  position: absolute;
+  border-radius: 0 3px 3px 0;
+  box-shadow: 0 3px 6px rgba(0,0,0,.4);
+  background: #9999FF;
+  width: 280px;
+  height: 1000px;
+`
+const Input = styled.input`
+  transition: background 85ms ease-in, border-color 85ms ease-in;
+  width: 95%;
+  border: 1px: solid grey;
+  border-radius: 3px;
+  background: #E2E4E6;
+  padding: 6px;
+  border: none;
+  height: 29px;
+  margin: 6px;
+  
+  &:focus {
+    background: white;
+  }
+`
+
+const Icon = styled.span`
+  font-size: 20px;
+  height: 20px;
+  width: 20px;
+  padding: 6px;
+  color: #DDDDDD;
+
+  &:hover {
+    color: grey;
+  }
+`
+
+const Pills = styled.div`
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  margin: 15px;
+  min-height: 35px;
+`
+
+const Pill = styled.div`
+  border-radius: 3px;
+  margin-top: 3px;
+  padding: 6px;
+  background: #DDDDDD;
+  width: 100%;
+`
+
+const Text = styled.span`
+  color: #DDDDDD;
+`
+
+const Button = styled.button`
+  padding: 0;
+  cursor: pointer;
+  color: #DDDDDD;  
+  background: #9999FF;
+  border-radius: 4px;
+  outline: none;
+  border: none;
+
+  ${props => props.pull_right && css`
+    margin-left: auto;
+  `}
+
+  ${props => props.secondary && css`
+    border-radius: 3px;
+    color: grey;
+    display: block;
+    margin-top: 3px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 6px;
+    background: #DDDDDD;
+    width: 95%;
+
+    &:hover {
+      color: #4c4c4c;
+      background: #cacaca;
+    }
+  `}
+
+  ${props => props.zippy && css`
+    height: 32px;
+    width: 32px;
+
+    &:hover {
+      color: grey;
+      background: #DDDDDD;
+    }
+`}
+`
+
+export {
+  Button,
+  Wrapper,
+  Text,
+  Input,
+  Icon,
+  Pills,
+  Pill
+}

--- a/src/components/Boards/Components/ZippyMenu.js
+++ b/src/components/Boards/Components/ZippyMenu.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import { Pills, Pill, Button, Text, Icon } from '../Boards.styles'
+
+class ZippyMenu extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { open: false }
+  }
+
+  toggleZippy = () => {
+    this.setState({ open: !this.state.open })
+  }
+
+  render() {
+    return (
+      <Pills>
+        <Text>{this.props.title}</Text>
+        <Button zippy pull_right onClick={this.toggleZippy}>
+          {
+            this.state.open ? <Icon className="fa fa-minus" /> :
+            <Icon className="fa fa-plus" />
+          }
+        </Button>
+        {
+          this.state.open ? <Pill><span>No Boards Made yet</span></Pill> : ''
+        }
+      </Pills>
+    )
+  }
+}
+
+export default ZippyMenu

--- a/src/components/Boards/ZippyMenu/ZippyMenu.js
+++ b/src/components/Boards/ZippyMenu/ZippyMenu.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import { Pills, Pill, Button, Text, Icon } from '../Boards.styles'
+import { Button, Text, Icon } from '../Boards.styles'
+import { Pills, Pill } from './ZippyMenu.styles'
 
 class ZippyMenu extends Component {
   constructor(props) {

--- a/src/components/Boards/ZippyMenu/ZippyMenu.styles.js
+++ b/src/components/Boards/ZippyMenu/ZippyMenu.styles.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+
+const Pills = styled.div`
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  margin: 15px;
+  min-height: 35px;
+`
+
+const Pill = styled.div`
+  border-radius: 3px;
+  margin-top: 3px;
+  padding: 6px;
+  background: #DDDDDD;
+  width: 100%;
+`
+
+export {
+  Pills,
+  Pill
+}

--- a/src/components/Components.js
+++ b/src/components/Components.js
@@ -1,5 +1,6 @@
 import App from './App/App'
 import Board from './Board/Board'
+import Boards from './Boards/Boards'
 import Callback from './Callback/Callback'
 import Home from './Home/Home'
 import LoggedOut from './LoggedOut/LoggedOut'
@@ -8,8 +9,9 @@ import Toolbar from './Toolbar/Toolbar'
 
 export {
   App,
-  Callback,
   Board,
+  Boards,
+  Callback,
   Home,
   LoggedOut,
   Profile,

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -2,8 +2,6 @@ import React, { Component, Fragment } from 'react'
 import { Link } from 'react-router-dom'
 import axios from 'axios'
 import Auth from '../../services/auth'
-import { Toolbar } from '../Components'
-
 
 const auth = new Auth()
 
@@ -14,12 +12,19 @@ class Home extends Component {
       authMessage: '',
     }
   }
+
+  // will re-render App.js
+  componentDidMount() {
+    this.props.authStateChanged()
+  }
+
   // calls the login method in authentication service
   login = () => {
     auth.login()
   }
   // calls the logout method in authentication service
   logout = () => {
+    this.props.resetMenuState()
     auth.logout()
   }
   // sends our access token to the server so
@@ -45,7 +50,7 @@ class Home extends Component {
     const { isAuthenticated } = auth
     return (
       <div>
-        <Toolbar />
+        {/* <Toolbar /> */}
         <h1>Home</h1>
         {isAuthenticated() ?
           <Fragment>

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Toolbar } from '../Components'
 import { Auth } from '../../services/Services'
 
 const auth = new Auth()
@@ -9,7 +8,6 @@ const { isAuthenticated } = auth
 const Profile = () => (
   isAuthenticated() &&
   <div>
-    <Toolbar />
     <h1>Profile</h1>
   </div>
 )

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -1,25 +1,45 @@
-import React from 'react'
+import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 
 import { Auth } from '../../services/Services'
-import { Wrapper, Button, Brand, Input } from './Toolbar.styles'
+import { Wrapper, Button, Brand, Input, Icon } from './Toolbar.styles'
+import Boards from '../Boards/Boards'
 
 const auth = new Auth()
 
 const { isAuthenticated } = auth
 
-const Toolbar = () => (
-  isAuthenticated() &&
-  <Wrapper>
-    <Button>Boards</Button>
-    <Input type="search" />
-    <Brand>
-      <Link to="/">Trello Clone</Link>
-    </Brand>
-    <Button pull_right>Create</Button>
-    <Button>Notifications</Button>
-    <Button>Profile</Button>
-  </Wrapper>
-)
+class Toolbar extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { isActive: false }
+  }
+  toggleBoards = () => {
+    this.setState({ isActive: !this.state.isActive })
+  }
+
+  render() {
+    return (
+      isAuthenticated() &&
+      <Wrapper>
+        {this.state.isActive ? <Boards /> : ''}
+        <Button onClick={this.toggleBoards}>Boards</Button>
+        <Input type="search" />
+        <Brand>
+          <Link to="/">Trello Clone</Link>
+        </Brand>
+        <Button pull_right>
+          <Icon className="fa fa-plus" />
+        </Button>
+        <Button>
+          <Icon className="fa fa-info" />
+        </Button>
+        <Button>
+          <Icon className="fa fa-bell" />
+        </Button>
+      </Wrapper>
+    )
+  }
+}
 
 export default Toolbar

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { Link } from 'react-router-dom'
 
 import { Auth } from '../../services/Services'
@@ -19,11 +19,19 @@ class Toolbar extends Component {
   }
 
   render() {
-    return (
-      isAuthenticated() &&
-      <Wrapper>
-        {this.state.isActive ? <Boards /> : ''}
-        <Button onClick={this.toggleBoards}>Boards</Button>
+    const BoardsJSX = (
+      <Boards
+        toggleFixedMenu={this.props.toggleFixedMenu}
+        keepOpen={this.props.keepOpen}
+      />)
+
+    const ContentJSX = (
+      <Fragment>
+        {this.state.isActive && BoardsJSX
+        }
+        {!this.props.keepOpen &&
+          <Button onClick={this.toggleBoards}>Boards</Button>
+        }
         <Input type="search" />
         <Brand>
           <Link to="/">Trello Clone</Link>
@@ -37,7 +45,22 @@ class Toolbar extends Component {
         <Button>
           <Icon className="fa fa-bell" />
         </Button>
-      </Wrapper>
+      </Fragment>
+    )
+
+    return (
+      isAuthenticated() &&
+      <Fragment>
+        {this.props.keepOpen ? BoardsJSX : ''}
+        {this.props.keepOpen ?
+          <Wrapper offset>
+            {ContentJSX}
+          </Wrapper> :
+          <Wrapper>
+            {ContentJSX}
+          </Wrapper>
+        }
+      </Fragment>
     )
   }
 }

--- a/src/components/Toolbar/Toolbar.styles.js
+++ b/src/components/Toolbar/Toolbar.styles.js
@@ -1,16 +1,20 @@
 import styled, { css } from 'styled-components'
 
 const Wrapper = styled.section`
-  width: 100%;
-  height: 35px;
+  height: 32px;
   display: flex;
   overflow: hidden;
   justify-content: space-between;
-  padding: 5px 0;
+  padding: 4px 0;
   z-index: 10;
 
   box-shadow: 0 1px 1px rgba(0,0,0,.1);
   background: #FFFFCC;
+
+  ${props => props.offset && css`
+    position: relative;
+    margin-left: 280px;
+  `}
 `
 
 const Icon = styled.span`

--- a/src/components/Toolbar/Toolbar.styles.js
+++ b/src/components/Toolbar/Toolbar.styles.js
@@ -13,6 +13,15 @@ const Wrapper = styled.section`
   background: #FFFFCC;
 `
 
+const Icon = styled.span`
+  font-size: 20px;
+  height: 20px;
+  width: 20px;
+  padding: 6px;
+  
+  color: white;
+`
+
 const Brand = styled.div`
   position: absolute;
   left: 45%;
@@ -25,15 +34,21 @@ const Brand = styled.div`
 `
 
 const Input = styled.input`
+  width: 210px;
+  border-radius: 3px;
   margin: 0 5px 0 5px;
+  border: none;
 `
 
 const Button = styled.button`
   cursor: pointer;
+  font-weight: 700;
   margin: 0 5px 0 5px;
   border-radius: 4px;
   outline: none;
   border: none;
+
+  color: white;
 
   ${props => props.pull_right && css`
     margin-left: auto;
@@ -44,5 +59,6 @@ export {
   Wrapper,
   Brand,
   Input,
+  Icon,
   Button
 }


### PR DESCRIPTION
### Features
- The user can choose the layout of the side-menu.
- The user can expand a sub menu (A.K.A a zippy-menu) for starred, recent, personal, and shared boards.
### Description
I had to change quite a few things to get the behavior I wanted so I'll do the best I can to explain each of them.
#### 1. Move Toolbar.js inside the App.js component.
There is a new feature that allows you to customize the side-menu layout involves pushing the entire viewport 30% to the right. In order to do this I had to render `<Toolbar />` as a sibling to `<Routes />` in `App.js`. `Toolbar.js` being nested inside `Home.js`, `Board.js`, and `Profile.js` made it impossible to affect the layout.
#### 2. Added state to App.js
The changes I made required the usage of state inside of `App.js`. 
- _keepOpen_: A boolean that keeps track of the side-menu layout state. This will keep the layout from being lost when you visit other parts of the app.
- _isAuthenticated_: We have to keep track of this value in `App.js` so we can re-render the component when the user's auth status changes and protect against unauthorized users.

There are a lot of changes here so if you think it can be reduced please let me know your thoughts in the comments.

🔥 Thank you!